### PR TITLE
Indent produced YAML in a more 'traditional' format that validates with yamlv 

### DIFF
--- a/cfn_flip/__init__.py
+++ b/cfn_flip/__init__.py
@@ -14,6 +14,12 @@ from .custom_yaml import yaml
 import collections
 import json
 
+class MyDumper(yaml.Dumper):
+
+  def increase_indent(self,flow=False,indentless=False):
+    return super(MyDumper,self).increase_indent(flow,False)
+
+
 def to_json(template, clean_up=False):
     """
     Convert the data to json
@@ -38,7 +44,7 @@ def to_yaml(template, clean_up=False):
     if clean_up:
         data = clean(data)
 
-    return yaml.dump(data, default_flow_style=False)
+    return yaml.dump(data, Dumper=MyDumper , default_flow_style=False)
 
 def flip(template, clean_up=False):
     """

--- a/cfn_flip/__init__.py
+++ b/cfn_flip/__init__.py
@@ -15,10 +15,14 @@ import collections
 import json
 
 class MyDumper(yaml.Dumper):
-
-  def increase_indent(self,flow=False,indentless=False):
-    return super(MyDumper,self).increase_indent(flow,False)
-
+  """
+  Indent block sequences from parent using more common style
+  ("  - entry"  vs "- entry").  
+  Causes fewer problems with validation and tools.
+  """
+  
+  def increase_indent(self,flow=False, indentless=False):
+    return super(MyDumper,self).increase_indent(flow, False)
 
 def to_json(template, clean_up=False):
     """
@@ -44,7 +48,7 @@ def to_yaml(template, clean_up=False):
     if clean_up:
         data = clean(data)
 
-    return yaml.dump(data, Dumper=MyDumper , default_flow_style=False)
+    return yaml.dump(data, Dumper=MyDumper, default_flow_style=False)
 
 def flip(template, clean_up=False):
     """


### PR DESCRIPTION
The indentation format for flows produced by yaml.dump(), while strictly valid, fails to parse in many YAML tools.  For example yamllint and yamlv produce errors (not warnings).

This patch adds a 'suggested' change to yaml.dump() to indent nested block flows.

[pyyaml ticket# 64](http://pyyaml.org/ticket/64)
Result:
Prior:
```

tag:
- entry1
- entry2

```
After:
```

tag:
  - entry1
  - entry2

```
