### PR TITLE
Use a custom yaml Loader and Dumper

### DIFF
--- a/cfn_flip/__init__.py
+++ b/cfn_flip/__init__.py
@@ -10,19 +10,11 @@ or in the "license" file accompanying this file. This file is distributed on an 
 
 from .clean import clean
 from .custom_json import DateTimeAwareJsonEncoder
-from .custom_yaml import custom_yaml
+from .custom_yaml import CustomDumper, CustomLoader
 import collections
 import json
+import yaml
 
-class MyDumper(custom_yaml.Dumper):
-  """
-  Indent block sequences from parent using more common style
-  ("  - entry"  vs "- entry").  
-  Causes fewer problems with validation and tools.
-  """
-  
-  def increase_indent(self,flow=False, indentless=False):
-    return super(MyDumper,self).increase_indent(flow, False)
 
 def to_json(template, clean_up=False):
     """
@@ -30,7 +22,7 @@ def to_json(template, clean_up=False):
     undoing yaml short syntax where detected
     """
 
-    data = custom_yaml.load(template)
+    data = yaml.load(template, Loader=CustomLoader)
 
     if clean_up:
         data = clean(data)
@@ -48,7 +40,7 @@ def to_yaml(template, clean_up=False):
     if clean_up:
         data = clean(data)
 
-    return custom_yaml.dump(data, Dumper=MyDumper, default_flow_style=False)
+    return yaml.dump(data, Dumper=CustomDumper, default_flow_style=False)
 
 def flip(template, clean_up=False):
     """

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         "six",
     ],
     zip_safe=False,
+    test_suite="tests",
     entry_points={
         "console_scripts": ["cfn-flip=cfn_flip.main:main"],
     },

--- a/tests/test_flip.py
+++ b/tests/test_flip.py
@@ -9,9 +9,10 @@ or in the "license" file accompanying this file. This file is distributed on an 
 """
 
 import cfn_flip
+from cfn_flip.custom_yaml import CustomLoader
 import json
 import unittest
-from cfn_flip.custom_yaml import custom_yaml
+import yaml
 
 
 class CfnFlipTestCase(unittest.TestCase):
@@ -33,10 +34,10 @@ class CfnFlipTestCase(unittest.TestCase):
             self.clean_yaml = f.read()
 
         self.parsed_json = json.loads(self.input_json)
-        self.parsed_yaml = custom_yaml.load(self.input_yaml)
+        self.parsed_yaml = yaml.load(self.input_yaml, Loader=CustomLoader)
 
         self.parsed_clean_json = json.loads(self.clean_json)
-        self.parsed_clean_yaml = custom_yaml.load(self.clean_yaml)
+        self.parsed_clean_yaml = yaml.load(self.clean_yaml, Loader=CustomLoader)
 
         self.bad_data = "<!DOCTYPE html>\n\n<html>\n\tThis isn't right!\n</html>"
 
@@ -76,7 +77,7 @@ class CfnFlipTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             json.loads(actual)
 
-        parsed_actual = custom_yaml.load(actual)
+        parsed_actual = yaml.load(actual, Loader=CustomLoader)
 
         self.assertDictEqual(parsed_actual, self.parsed_yaml)
 
@@ -111,7 +112,7 @@ class CfnFlipTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             json.loads(actual)
 
-        parsed_actual = custom_yaml.load(actual)
+        parsed_actual = yaml.load(actual, Loader=CustomLoader)
 
         self.assertDictEqual(parsed_actual, self.parsed_yaml)
 
@@ -139,7 +140,7 @@ class CfnFlipTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             json.loads(actual)
 
-        parsed_actual = custom_yaml.load(actual)
+        parsed_actual = yaml.load(actual, Loader=CustomLoader)
 
         self.assertDictEqual(parsed_actual, self.parsed_clean_yaml)
 

--- a/tests/test_yaml_patching.py
+++ b/tests/test_yaml_patching.py
@@ -9,6 +9,7 @@ or in the "license" file accompanying this file. This file is distributed on an 
 """
 
 import cfn_flip
+import collections
 import json
 import unittest
 import yaml
@@ -19,7 +20,7 @@ class YamlPatchTestCase(unittest.TestCase):
     Check that we don't patch yaml for everybody
     """
 
-    def test_yaml_ordered_dict(self):
+    def test_yaml_no_ordered_dict(self):
         """
         cfn-flip patches yaml to use OrderedDict by default
         Check that we don't do this for folks who import cfn_flip and yaml
@@ -29,3 +30,14 @@ class YamlPatchTestCase(unittest.TestCase):
         data = yaml.load(yaml_string)
 
         self.assertEqual(type(data), dict)
+
+    def test_yaml_no_ordered_dict(self):
+        """
+        cfn-flip patches yaml to use OrderedDict by default
+        Check that we do this for normal cfn_flip use cases
+        """
+
+        yaml_string = "key: value"
+        data = yaml.load(yaml_string, Loader=cfn_flip.CustomLoader)
+
+        self.assertEqual(type(data), collections.OrderedDict)


### PR DESCRIPTION
During yaml transformations cfn_flip converts dicts to OrderedDict which
could conflict with other uses of yaml in a program. This change implements
a custom yaml loader and dumper to isolate the OrderedDict conversion to
just the cfn_flip transformations.

This fixes #21, reverts most of #17, and is an alternative fix to #14.