### PR TITLE
Fix for errors with handling of !GetAtt

### DIFF
--- a/cfn_flip/custom_json.py
+++ b/cfn_flip/custom_json.py
@@ -1,9 +1,10 @@
 from datetime import date, datetime, time
 import json
 
+
 class DateTimeAwareJsonEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, (datetime, date)):
             return obj.isoformat()
 
-        return json.JSONEncoder.default(self, o)
+        return json.JSONEncoder.default(self, obj)

--- a/cfn_flip/custom_yaml.py
+++ b/cfn_flip/custom_yaml.py
@@ -47,7 +47,6 @@ def construct_getatt(node):
     """
     Reconstruct !GetAtt into a list
     """
-    print(node)
     if isinstance(node.value, str):
         return node.value.split(".")
     elif isinstance(node.value, list):

--- a/cfn_flip/custom_yaml.py
+++ b/cfn_flip/custom_yaml.py
@@ -47,8 +47,13 @@ def construct_getatt(node):
     """
     Reconstruct !GetAtt into a list
     """
-
-    return node.value.split(".")
+    print(node)
+    if isinstance(node.value, str):
+        return node.value.split(".")
+    elif isinstance(node.value, list):
+        return [s.value for s in node.value]
+    else:
+        raise ValueError("Unexpected node type")
 
 def construct_mapping(self, node, deep=False):
     """


### PR DESCRIPTION
This is a fix for a recently encountered issue where this library is unable to handle a variation of the GetAtt syntax in YAML.

The `!GetAtt Resource.Property ` syntax works.

The more verbose JSON version also works.
```
"Fn::GetAtt": [
    "Resource",
    "Property"
]
```

But we have had some YAML templates which use a syntax which should be perfectly valid, as it is just a simple json -> yaml conversion of what is above:
```
!GetAtt
   - Resource
   - Property
```

This gave an AttributeError, as the `construct_getatt` function expects the value to be a string to split on, but a list is returned in this scenario and obviously, it does not have `split` as an attribute.

This PR should fix this issue by doing a simple `isisnstance` check.
Also fixed (a typo?) in the custom_json file.

Please let me know if there's anything else needing to be done for this to be merged in.

Thanks,
Patrick