### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     author="Steve Engledow",
     author_email="sengledo@amazon.co.uk",
     license="Apache2",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests"]),
     install_requires=[
         "Click",
         "PyYAML",


### PR DESCRIPTION
When using the servereless framework with troposphere this project is pulled since it's included in the setup.py of troposphere since version 2.1.2 and the "tests" file being included causes deployments to fail since tests is a common folder in our microservice projects.