### PR TITLE
Fix conversion of dotted GetAtt attributes from YAML to JSON

### DIFF
--- a/cfn_tools/yaml_loader.py
+++ b/cfn_tools/yaml_loader.py
@@ -53,7 +53,7 @@ def construct_getatt(node):
     """
 
     if isinstance(node.value, six.text_type):
-        return node.value.split(".")
+        return node.value.split(".", 1)
     elif isinstance(node.value, list):
         return [s.value for s in node.value]
     else:

--- a/tests/test_flip.py
+++ b/tests/test_flip.py
@@ -263,7 +263,7 @@ def test_flip_to_json_with_multi_level_getatt():
     data = "!GetAtt 'First.Second.Third'\n"
 
     expected = {
-        "Fn::GetAtt": ["First", "Second", "Third"]
+        "Fn::GetAtt": ["First", "Second.Third"]
     }
 
     actual = cfn_flip.to_json(data, clean_up=True)


### PR DESCRIPTION
Fn::GetAtt [only supports two arguments in JSON](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html).

Some resource types have dotted attributes available, e.g. Endpoint.Address on AWS::RDS::DBInstance. The existing functionality was causing output such as:

```json
"Fn::GetAtt": [
    "SentryRDSInstance",
    "Endpoint",
    "Port"
]
```

This fails CloudFormation validation:

```
An error occurred (ValidationError) when calling the ValidateTemplate operation: Template error: every Fn::GetAtt object requires two non-empty parameters, the resource name and the resource attribute
```