### PR TITLE
Add Codecov coverate reporting and badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://www.travis-ci.org/awslabs/aws-cfn-template-flip.svg?branch=master)](https://www.travis-ci.org/awslabs/aws-cfn-template-flip)
 [![PyPI version](https://badge.fury.io/py/cfn_flip.svg)](https://badge.fury.io/py/cfn_flip)
+[![Codecov Test Coverage](https://codecov.io/gh/awslabs/aws-cfn-template-flip/branch/master/graphs/badge.svg?style=flat)](https://codecov.io/gh/awslabs/aws-cfn-template-flip)
 
 # AWS CloudFormation Template Flip
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps =
     pytest<3.8.0
     pytest-cov
     pytest-sugar
+    codecov>=1.4.0
 
 commands =
     py.test \
@@ -20,6 +21,9 @@ commands =
         --cov-report term-missing \
         --cov-report html \
         {posargs}
+    codecov -e TOXENV
+
+passenv = TOXENV CI TRAVIS TRAVIS_*
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
Hey, Tom from Codecov here.  I thought it would be useful to add code coverage metrics to this repository. [Codecov](https://codecov.io) is a hosted code coverage provider with awesome features. You can checkout your first reports [here](https://codecov.io/gh/thomasrockhu/aws-cfn-template-flip).  I also updated the `README` with a coverage badge.

Codecov ❤️'s open source and will be free forever for OSS

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
