### PR TITLE
[tests] Replace 'message' in pytest.raises with 'match'

### DIFF
--- a/tests/test_odict.py
+++ b/tests/test_odict.py
@@ -74,7 +74,7 @@ def test_constructor_disallows_dict():
     as ordering will be lost
     """
 
-    with pytest.raises(Exception, message="ODict does not allow construction from a dict"):
+    with pytest.raises(Exception, match="ODict does not allow construction from a dict"):
         ODict({
             "z": 1,
             "a": 2,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -80,6 +80,7 @@ def test_dump_json():
     JSON dumping just needs to know about datetimes,
     provide a nice indent, and preserve order
     """
+    import sys
 
     source = ODict((
         ("z", datetime.time(3, 45)),
@@ -95,7 +96,14 @@ def test_dump_json():
         "a": "2012-05-02T03:45:00",
     }
 
-    with pytest.raises(TypeError, message="complex is not JSON serializable"):
+    if sys.version_info < (3, 6):
+        fail_message = "\(1\+1j\) is not JSON serializable"
+    elif sys.version_info< (3, 7):
+        fail_message = "Object of type 'complex' is not JSON serializable"
+    else:
+        fail_message = "Object of type complex is not JSON serializable"
+
+    with pytest.raises(TypeError, match=fail_message):
         dump_json({
             "c": 1 + 1j,
         })


### PR DESCRIPTION
There's a common confusion between both, see pytest-dev/pytest#3974

The patterns for match needed some adjustments due to the changes made to the error messages since the initial switch to pytest.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
