### PR TITLE
Fixed AWS::NoValue issue #69

### DIFF
--- a/cfn_clean/__init__.py
+++ b/cfn_clean/__init__.py
@@ -55,7 +55,7 @@ def convert_join(value):
                 for key, val in args.items():
                     # we want to bail if a conditional can evaluate to AWS::NoValue
                     if isinstance(val, dict):
-                        if "Fn::If" in val and "AWS::NoValue" in val["Fn::If"]:
+                        if "Fn::If" in val and "AWS::NoValue" in str(val["Fn::If"]):
                             return {
                                 "Fn::Join": value,
                             }

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -265,7 +265,7 @@ def test_gh_63_no_value():
                     "Fn::If": [
                         "Condition1",
                         "True1",
-                        "AWS::NoValue"
+                        "Ref: AWS::NoValue"
                     ]
                 },
                 {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This PR fixes the issue #69 with minimum changes:

- There is already recursive check for "AWS::NoValue" in the clean / convert_join methods. But it is strictly looking for "AWS:NoValue" as list element within "Fn::If". But [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html#cfn-pseudo-param-novalue) indicates that it is pseudo-parameter with "Ref" call.  E.g.,

```yaml
    DBSnapshotIdentifier:
      Fn::If:
      - UseDBSnapshot
      - Ref: DBSnapshotName
      - Ref: AWS::NoValue
```

- The fix is simply changing to check "AWS:NoValue" presence in string text value of list element so that it works with or without "Ref"
- The pytest case is updated to include "Ref" prefix and has passed with same 100% coverage for clean module.