### PR TITLE
yaml.load() to yaml.safe_load()

### DIFF
--- a/cfn_tools/__init__.py
+++ b/cfn_tools/__init__.py
@@ -26,7 +26,7 @@ def dump_json(source):
 
 
 def load_yaml(source):
-    return yaml.load(source, Loader=CfnYamlLoader)
+    return yaml.safe_load(source,loader=CfnYamlLoader)
 
 
 def dump_yaml(source):

--- a/tests/test_flip.py
+++ b/tests/test_flip.py
@@ -543,8 +543,8 @@ def test_flip_to_yaml_with_longhand_functions(input_json, parsed_json):
     actual2 = cfn_flip.to_yaml(input_json, long_form=True)
 
     # No custom loader as there should be no custom tags
-    parsed_actual1 = yaml.load(actual1)
-    parsed_actual2 = yaml.load(actual2)
+    parsed_actual1 = yaml.safe_load(actual1)
+    parsed_actual2 = yaml.safe_load(actual2)
 
     # We use the parsed JSON as it contains long form function calls
     assert parsed_actual1 == parsed_json

--- a/tests/test_yaml_patching.py
+++ b/tests/test_yaml_patching.py
@@ -23,7 +23,7 @@ def test_yaml_no_ordered_dict():
     """
 
     yaml_string = "key: value"
-    data = yaml.load(yaml_string)
+    data = yaml.safe_load(yaml_string)
 
     assert type(data) == dict
 


### PR DESCRIPTION
Change from yaml.load to yaml.safe_load seems to mitigate the issue. One way to test whether there is any issue is to

'''
cat test
!!python/object/apply:os.system ["say \"what could possibly go wrong\""]

cfn-flip test
'''
https://snyk.io/vuln/SNYK-PYTHON-PYYAML-42159

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
