### PR TITLE
Fixed flake8 warnings

### DIFF
--- a/cfn_flip/__init__.py
+++ b/cfn_flip/__init__.py
@@ -112,5 +112,4 @@ def flip(template, in_format=None, out_format=None, clean_up=False, no_flip=Fals
         else:
             return dump_json(data).encode('utf-8')
 
-
     return dump_yaml(data, clean_up, long_form)

--- a/cfn_tools/yaml_dumper.py
+++ b/cfn_tools/yaml_dumper.py
@@ -24,16 +24,16 @@ class CfnYamlDumper(yaml.Dumper):
     """
 
     def increase_indent(self, flow=False, indentless=False):
-            return super(CfnYamlDumper, self).increase_indent(flow, False)
+        return super(CfnYamlDumper, self).increase_indent(flow, False)
 
     def represent_scalar(self, tag, value, style=None):
-            if isinstance(value, six.text_type):
-                if any(eol in value for eol in "\n\r") and style is None:
-                    style = "\""
+        if isinstance(value, six.text_type):
+            if any(eol in value for eol in "\n\r") and style is None:
+                style = "\""
 
-                # return super(CfnYamlDumper, self).represent_scalar(TAG_STRING, value, style)
+            # return super(CfnYamlDumper, self).represent_scalar(TAG_STRING, value, style)
 
-            return super(CfnYamlDumper, self).represent_scalar(tag, value, style)
+        return super(CfnYamlDumper, self).represent_scalar(tag, value, style)
 
 
 def string_representer(dumper, value):

--- a/tests/test_flip.py
+++ b/tests/test_flip.py
@@ -23,6 +23,7 @@ except ImportError:
     # Python < 3.5
     JSONDecodeError = ValueError
 
+
 @pytest.fixture
 def input_json():
     with open("examples/test.json", "r") as f:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -97,8 +97,8 @@ def test_dump_json():
     }
 
     if sys.version_info < (3, 6):
-        fail_message = "\(1\+1j\) is not JSON serializable"
-    elif sys.version_info< (3, 7):
+        fail_message = r"\(1\+1j\) is not JSON serializable"
+    elif sys.version_info < (3, 7):
         fail_message = "Object of type 'complex' is not JSON serializable"
     else:
         fail_message = "Object of type complex is not JSON serializable"


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

- Fixed minor flake8 warnings
- Flake8 is configured in `tox.ini` but it is not executed by travis ci. So the CI job is fine but local `tox` run will fail because of such flake8 warnings
