### PR TITLE
Fix Json string literal in resource property

### DIFF
--- a/cfn_flip/__init__.py
+++ b/cfn_flip/__init__.py
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and limitations 
 """
 
 from .yaml_dumper import get_dumper
-from cfn_clean import clean
+from cfn_clean import clean, cfn_literal_parser
 from cfn_tools import load_json, load_yaml, dump_json
 import yaml
 import sys
@@ -60,7 +60,7 @@ def to_json(template, clean_up=False):
     return dump_json(data)
 
 
-def to_yaml(template, clean_up=False, long_form=False):
+def to_yaml(template, clean_up=False, long_form=False, literal=True):
     """
     Assume the input is JSON and convert to YAML
     """
@@ -69,6 +69,9 @@ def to_yaml(template, clean_up=False, long_form=False):
 
     if clean_up:
         data = clean(data)
+
+    if literal:
+        data = cfn_literal_parser(data)
 
     return dump_yaml(data, clean_up, long_form)
 

--- a/cfn_flip/yaml_dumper.py
+++ b/cfn_flip/yaml_dumper.py
@@ -12,10 +12,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and limitations under the License.
 """
 
+import six
+
 from cfn_clean.yaml_dumper import CleanCfnYamlDumper
+from cfn_tools.literal import LiteralString
 from cfn_tools.odict import ODict
 from cfn_tools.yaml_dumper import CfnYamlDumper
-import six
 
 TAG_STR = "tag:yaml.org,2002:str"
 TAG_MAP = "tag:yaml.org,2002:map"
@@ -51,6 +53,10 @@ class LongCleanDumper(CleanCfnYamlDumper):
     """
     Preserves long-form function syntax
     """
+
+
+def literal_unicode_representer(dumper, value):
+    return dumper.represent_scalar(TAG_STR, value, style='|')
 
 
 def string_representer(dumper, value):
@@ -103,6 +109,8 @@ def map_representer(dumper, value):
 # Customise our dumpers
 Dumper.add_representer(ODict, map_representer)
 Dumper.add_representer(six.text_type, string_representer)
+Dumper.add_representer(LiteralString, literal_unicode_representer)
+CleanDumper.add_representer(LiteralString, literal_unicode_representer)
 CleanDumper.add_representer(ODict, map_representer)
 
 

--- a/cfn_tools/literal.py
+++ b/cfn_tools/literal.py
@@ -1,0 +1,15 @@
+"""
+Copyright 2016-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
+
+    http://aws.amazon.com/apache2.0/
+
+or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+"""
+
+class LiteralString(str):
+    """
+    Class to represent json literal
+    """
+    pass

--- a/cfn_tools/yaml_dumper.py
+++ b/cfn_tools/yaml_dumper.py
@@ -1,22 +1,42 @@
 """
 Copyright 2016-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+A copy of the License is located at
 
     http://aws.amazon.com/apache2.0/
 
-or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and limitations under the License.
 """
 
-from .odict import ODict
 import six
 import yaml
+from yaml.emitter import Emitter, ScalarAnalysis
+
+from .literal import LiteralString
+from .odict import ODict
 
 TAG_MAP = "tag:yaml.org,2002:map"
 TAG_STRING = "tag:yaml.org,2002:str"
 
 
-class CfnYamlDumper(yaml.Dumper):
+class CfnEmitter(Emitter):
+    def analyze_scalar(self, scalar):
+        # We have Json payloads that we want to show as literal
+        # This way we can skip the checks that analize_scalar do in the string when you have
+        # leading_space or leading_break
+        if not scalar or isinstance(scalar, LiteralString):
+            return ScalarAnalysis(scalar=scalar, empty=True, multiline=False,
+                                  allow_flow_plain=False, allow_block_plain=True,
+                                  allow_single_quoted=True, allow_double_quoted=True,
+                                  allow_block=True)
+        return super(CfnEmitter, self).analyze_scalar(scalar)
+
+
+class CfnYamlDumper(yaml.Dumper, CfnEmitter):
     """
     Indent block sequences from parent using more common style
     ("  - entry"  vs "- entry").
@@ -53,6 +73,11 @@ def map_representer(dumper, value):
     return dumper.represent_mapping(TAG_MAP, value)
 
 
+def literal_unicode_representer(dumper, value):
+    return dumper.represent_scalar(TAG_STRING, value, style='|')
+
+
 # Customise the dumper
 CfnYamlDumper.add_representer(ODict, map_representer)
+CfnYamlDumper.add_representer(LiteralString, literal_unicode_representer)
 CfnYamlDumper.add_representer(six.text_type, string_representer)

--- a/examples/test_json_data.json
+++ b/examples/test_json_data.json
@@ -1,0 +1,26 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Transform": "AWS::Serverless-2016-10-31",
+    "Resources": {
+        "ExampleStateMachineResource": {
+            "Type": "AWS::StepFunctions::StateMachine",
+            "Properties": {
+                "DefinitionString": {
+                  "StartAt": "First State",
+                  "States": {
+                    "First State": {
+                      "Type": "Task",
+                      "Resource": "FunctionARN",
+                      "Next": "Second State"
+                    },
+                    "Second State": {
+                      "Type": "Task",
+                      "Resource": "FunctionARN",
+                      "End": true
+                    }
+                  }
+                }
+            }
+        }
+    }
+}

--- a/examples/test_json_data.yaml
+++ b/examples/test_json_data.yaml
@@ -1,0 +1,22 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  ExampleStateMachineResource:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      DefinitionString: |-
+        {
+          "StartAt": "First State",
+          "States": {
+            "First State": {
+              "Type": "Task",
+              "Resource": "FunctionARN",
+              "Next": "Second State"
+            },
+            "Second State": {
+              "Type": "Task",
+              "Resource": "FunctionARN",
+              "End": true
+            }
+          }
+        }

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     packages=find_packages(exclude=["tests"]),
     install_requires=[
         "Click",
-        "PyYAML>=3.13b1",
+        "PyYAML>=4.1",
         "six",
     ],
     tests_require=[

--- a/tests/test_flip.py
+++ b/tests/test_flip.py
@@ -37,6 +37,12 @@ def input_long_json():
 
 
 @pytest.fixture
+def input_json_with_literal():
+    with open("examples/test_json_data.json", "r") as f:
+        return f.read().strip()
+
+
+@pytest.fixture
 def input_yaml():
     with open("examples/test.yaml", "r") as f:
         return f.read().strip()
@@ -64,6 +70,12 @@ def multibyte_json():
 def multibyte_yaml():
     with open("examples/test_multibyte.yaml", "r") as f:
         return f.read().strip()
+
+
+@pytest.fixture
+def parsed_yaml_with_json_literal():
+    with open("examples/test_json_data.yaml") as f:
+        return load_yaml(f.read().strip())
 
 
 @pytest.fixture
@@ -615,3 +627,12 @@ def test_quoted_digits():
     actual = cfn_flip.to_yaml(value)
 
     assert actual == expected
+
+
+def test_flip_to_yaml_with_json_literal(input_json_with_literal, parsed_yaml_with_json_literal):
+    """
+    Test that load json with json payload that must stay json when converted to yaml
+    """
+
+    actual = cfn_flip.to_yaml(input_json_with_literal)
+    assert load_yaml(actual) == parsed_yaml_with_json_literal


### PR DESCRIPTION
*Fix:* This fix solves the issue with JSON payload in resource `AWS::StepFunctions::StateMachine` and property `DefinitionString` that has a JSON string that must remain a json string when converted to YAML.

### Details:

When the script load a json file all key/values are converted to objects and those objects and later converted to yaml. This behavior made some payloads like `DefinitionString` to become Yaml but the property is a json and in a Yaml document this property must be converted to a string literal.
The way to solve this is to run a parser that will check for `Key == AWS::StepFunctions::StateMachine` and when found this resource we try to find the property `DefinitionString`. If found the property we convert the object into a string using json.dumps
and create a python object to be specifically parsed in the yaml representer to use the style `|`.
Here is where the things get interesting.  
Just adding the style `|` to generate a literal didn't work as expected as some simple strings got converted correctly and others don't.

You can reproduce the behavior with this script:

```python
import yaml


class Literal(str):
    pass


def representer_literal(dumper, value):
    return dumper.represent_scalar(u"tag:yaml.org,2002:str", value, style='|')


if __name__ == '__main__':
    var = Literal(u"{\n  line1\n  line2\n  line3\n}")
    yaml.add_representer(Literal, representer_literal)
    print(yaml.dump({'a': var}))
    # Output:
    # a: |-
    #   {
    #     line1
    #     line2
    #     line3
    #   }
    var = Literal(u"{\n \"texto\"   \n line1\n  line2\n  line3\n}")
    print(yaml.dump({'a': var}))
    # Output:
    # a: "{\n \"texto\"   \n line1\n  line2\n  line3\n}"
```
After analysing the problem I found that pyYaml in the Emitter step there is a string validation to check against leading and trailing whitespaces.
The code is here: https://github.com/yaml/pyyaml/blob/master/lib/yaml/emitter.py

The way to circumvent this characteristic is to override the method `analyze_scalar`from class `Emitter` and when we find a scalar that is a instance of our object type `LiteralString` we return the `ScalarAnalisys` with the parameters that we want (In this case to `allow_block_plain=True`
> Other scalar types just get his normal flow using the `super()`

This solution allow an easy way to add more resource properties as the code has an array of  tuples of `(<Resource_Type>, <Property_Name>)`

---

*Fix:* Updated the PyYaml requirement in `setup.py` to >= 4.1 to avoid remote execution vulnerability in CVE-2017-18342
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
