### PR TITLE
Fix literal parser

### DIFF
--- a/cfn_tools/literal.py
+++ b/cfn_tools/literal.py
@@ -8,6 +8,7 @@ Licensed under the Apache License, Version 2.0 (the "License"). You may not use 
 or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 """
 
+
 class LiteralString(str):
     """
     Class to represent json literal

--- a/examples/test_json_def_string_with_sub.json
+++ b/examples/test_json_def_string_with_sub.json
@@ -1,0 +1,85 @@
+{
+    "Resources": {
+        "FeedbackRequestStateMachine": {
+            "Properties": {
+                "DefinitionString": {
+                    "Fn::Sub": [
+                        "\n        {\n            \"Comment\": \"State machine which awaits until defined date to submit a feedback request\",\n            \"StartAt\": \"WaitForDueDate\",\n            \"States\": {\n                \"WaitForDueDate\": {\n                    \"Type\": \"Wait\",\n                    \"TimestampPath\": \"$.plannedAt\",\n                    \"Next\": \"SubmitFeedbackRequestToSQS\"\n                },\n                \"SubmitFeedbackRequestToSQS\": {\n                    \"Type\": \"Task\",\n                    \"Resource\": \"arn:aws:states:::sqs:sendMessage\",\n                    \"Parameters\": {\n                        \"MessageBody.$\": \"$\",\n                        \"QueueUrl\": \"${feedbackQueueUrl}\"\n                    },\n                    \"End\": true\n                }\n            }\n        }\n        ",
+                        {
+                            "feedbackQueueUrl": {
+                                "Ref": "FeedbackRequestsQueue"
+                            }
+                        }
+                    ]
+                },
+                "RoleArn": {
+                    "Fn::Join": [
+                        "/",
+                        [
+                            {
+                                "Fn::Sub": "arn:aws:iam::${AWS::AccountId}:role"
+                            },
+                            {
+                                "Ref": "FeedbackRequestStateMachineRole"
+                            }
+                        ]
+                    ]
+                },
+                "StateMachineName": {
+                    "Fn::Sub": "${AWS::StackName}-FeedbackRequestStateMachine"
+                }
+            },
+            "Type": "AWS::StepFunctions::StateMachine"
+        },
+        "FeedbackRequestStateMachineRole": {
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [
+                        {
+                            "Action": [
+                                "sts:AssumeRole"
+                            ],
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    {
+                                        "Fn::Sub": "states.${AWS::Region}.amazonaws.com"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "Policies": [
+                    {
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Action": [
+                                        "sqs:SendMessage"
+                                    ],
+                                    "Effect": "Allow",
+                                    "Resource": {
+                                        "Fn::GetAtt": [
+                                            "FeedbackRequestsQueue",
+                                            "Arn"
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                        "PolicyName": "submit_request_to_sqs"
+                    }
+                ]
+            },
+            "Type": "AWS::IAM::Role"
+        },
+        "FeedbackRequestsQueue": {
+            "Properties": {
+                "MessageRetentionPeriod": 172800,
+                "VisibilityTimeout": 600
+            },
+            "Type": "AWS::SQS::Queue"
+        }
+    }
+}

--- a/examples/test_yaml_def_string_with_sub.yaml
+++ b/examples/test_yaml_def_string_with_sub.yaml
@@ -1,0 +1,47 @@
+Resources:
+  FeedbackRequestStateMachine:
+    Properties:
+      DefinitionString: !Sub
+        - "\n        {\n            \"Comment\": \"State machine which awaits until\
+          \ defined date to submit a feedback request\",\n            \"StartAt\"\
+          : \"WaitForDueDate\",\n            \"States\": {\n                \"WaitForDueDate\"\
+          : {\n                    \"Type\": \"Wait\",\n                    \"TimestampPath\"\
+          : \"$.plannedAt\",\n                    \"Next\": \"SubmitFeedbackRequestToSQS\"\
+          \n                },\n                \"SubmitFeedbackRequestToSQS\": {\n\
+          \                    \"Type\": \"Task\",\n                    \"Resource\"\
+          : \"arn:aws:states:::sqs:sendMessage\",\n                    \"Parameters\"\
+          : {\n                        \"MessageBody.$\": \"$\",\n               \
+          \         \"QueueUrl\": \"${feedbackQueueUrl}\"\n                    },\n\
+          \                    \"End\": true\n                }\n            }\n \
+          \       }\n        "
+        - feedbackQueueUrl: !Ref 'FeedbackRequestsQueue'
+      RoleArn: !Join
+        - /
+        - - !Sub 'arn:aws:iam::${AWS::AccountId}:role'
+          - !Ref 'FeedbackRequestStateMachineRole'
+      StateMachineName: !Sub '${AWS::StackName}-FeedbackRequestStateMachine'
+    Type: AWS::StepFunctions::StateMachine
+  FeedbackRequestStateMachineRole:
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - !Sub 'states.${AWS::Region}.amazonaws.com'
+      Policies:
+        - PolicyDocument:
+            Statement:
+              - Action:
+                  - sqs:SendMessage
+                Effect: Allow
+                Resource: !GetAtt 'FeedbackRequestsQueue.Arn'
+          PolicyName: submit_request_to_sqs
+    Type: AWS::IAM::Role
+  FeedbackRequestsQueue:
+    Properties:
+      MessageRetentionPeriod: 172800
+      VisibilityTimeout: 600
+    Type: AWS::SQS::Queue

--- a/tests/test_flip.py
+++ b/tests/test_flip.py
@@ -43,6 +43,18 @@ def input_json_with_literal():
 
 
 @pytest.fixture
+def input_json_with_def_string_with_sub():
+    with open("examples/test_json_def_string_with_sub.json", "r") as f:
+        return f.read().strip()
+
+
+@pytest.fixture
+def input_yaml_with_def_string_with_sub():
+    with open("examples/test_yaml_def_string_with_sub.yaml", "r") as f:
+        return f.read()
+
+
+@pytest.fixture
 def input_yaml():
     with open("examples/test.yaml", "r") as f:
         return f.read().strip()
@@ -636,3 +648,9 @@ def test_flip_to_yaml_with_json_literal(input_json_with_literal, parsed_yaml_wit
 
     actual = cfn_flip.to_yaml(input_json_with_literal)
     assert load_yaml(actual) == parsed_yaml_with_json_literal
+
+
+def test_flip_to_yaml_with_json_literal_with_sub(input_json_with_def_string_with_sub,
+                                                 input_yaml_with_def_string_with_sub):
+    actual = cfn_flip.to_yaml(input_json_with_def_string_with_sub)
+    assert actual == input_yaml_with_def_string_with_sub

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -149,7 +149,7 @@ def test_odict_fail_with_dict():
     items = {'key1': 'value1'}
     with pytest.raises(Exception) as e:
         ODict(items)
-    assert 'ODict does not allow construction from a dict' in str(e)
+    assert 'ODict does not allow construction from a dict' == str(e.value)
 
 
 def test_represent_scalar():
@@ -176,7 +176,7 @@ def test_multi_constructor_with_invalid_node_type():
     """
     with pytest.raises(Exception) as e:
         multi_constructor(None, None, None)
-    assert 'Bad tag: !Fn::None' in str(e)
+    assert 'Bad tag: !Fn::None' in str(e.value)
 
 
 def test_construct_getattr_with_invalid_node_type():
@@ -187,7 +187,7 @@ def test_construct_getattr_with_invalid_node_type():
     node = MockNode()
     with pytest.raises(ValueError) as e:
         construct_getatt(node)
-    assert 'Unexpected node type:' in str(e)
+    assert 'Unexpected node type:' in str(e.value)
 
 
 def test_construct_getattr_with_list():


### PR DESCRIPTION
Fix: Added intrinsic function check before parsing the `DefinitionString`
Fix: Changed assert comparison in some tests that stopped working with Python 3.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
