### PR TITLE
Override OrderedDict.items() properly in ODict

### DIFF
--- a/cfn_tools/odict.py
+++ b/cfn_tools/odict.py
@@ -44,5 +44,6 @@ class ODict(collections.OrderedDict):
 
         super(ODict, self).__init__(pairs)
 
-        old_items = self.items
-        self.items = lambda: OdictItems(old_items())
+    def items(self):
+        old_items = super(ODict, self).items()
+        return OdictItems(old_items)

--- a/tests/test_odict.py
+++ b/tests/test_odict.py
@@ -9,6 +9,8 @@ or in the "license" file accompanying this file. This file is distributed on an 
 """
 
 from cfn_tools.odict import ODict
+from copy import deepcopy
+import pickle
 import pytest
 
 
@@ -94,3 +96,29 @@ def test_explicit_sorting():
     actual = sorted(case)
 
     assert actual == case
+
+
+def test_post_deepcopy_repr():
+    """
+    Repr should behave normally after deepcopy
+    """
+
+    dct = ODict([("a", 1)])
+    dct2 = deepcopy(dct)
+    assert repr(dct) == repr(dct2)
+    dct2["b"] = 2
+    assert repr(dct) != repr(dct2)
+
+
+def test_pickle():
+    """
+    Should be able to pickle and unpickle
+    """
+
+    dct = ODict([
+        ("c", 3),
+        ("d", 4),
+    ])
+    data = pickle.dumps(dct)
+    dct2 = pickle.loads(data)
+    assert dct == dct2


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This pull request is to fix an issue I encountered when updating `ODict` object returned by `cfn_flip.load()`, a test case worth a thousand words:

```python
def test_post_deepcopy_repr():
    dct = ODict([("a", 1)])
    dct2 = deepcopy(dct)
    assert repr(dct) == repr(dct2)
    dct2["b"] = 2
    assert repr(dct) != repr(dct2)  # this fails before fix
```

Looking at `ODict.__init__()` I can see why, `items()` is not properly overridden, it's an easy fix by overriding `items()` properly.

I was curious so I tested it with pickle and unsurprisingly it didn't work as well, so I added `test_pickle` too.

Would appreciate we can get this bug fixed, currently I'm using the following **workaround** which is quite unpleasant:

```python
_cfn_odict_patched = False

def patch_cfn_odict():
    global _cfn_odict_patched

    if _cfn_odict_patched:
        return True

    def ODict_init(self, *args, **kwargs):
        ODict_init_orig(self, *args, **kwargs)
        delattr(self, 'items')

    def ODict_items(self):
        return OdictItems(super(ODict, self).items())

    ODict_init_orig = ODict.__init__
    ODict.__init__ = ODict_init
    ODict.items = ODict_items
    _cfn_odict_patched = True
```