### PR TITLE
Separate read/write steps of cfn-flip

### DIFF
--- a/cfn_flip/main.py
+++ b/cfn_flip/main.py
@@ -53,13 +53,14 @@ def main(ctx, **kwargs):
         ctx.exit()
 
     try:
-        output_file.write(flip(
+        flipped = flip(
             input_file.read(),
             in_format=in_format,
             out_format=out_format,
             clean_up=clean,
             no_flip=no_flip,
             long_form=long_form
-        ))
+        )
+        output_file.write(flipped)
     except Exception as e:
         raise click.ClickException("{}".format(e))

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="cfn_flip",
-    version="1.2.2",
+    version="1.2.3",
     description="Convert AWS CloudFormation templates between JSON and YAML formats",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Fixes https://github.com/awslabs/aws-cfn-template-flip/issues/91

The current process can lead to losing your template when specifying the
same input and output file, due to the write action interfering with the
read action.

This change performs the flip function, storing the result in memory,
then writing it. This allows users to use the same file as an
input and output.

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

