### PR TITLE
Fix: When StateMachine has a string policy

### DIFF
--- a/cfn_clean/__init__.py
+++ b/cfn_clean/__init__.py
@@ -148,7 +148,8 @@ def cfn_literal_parser(source):
                         # Checking if this resource has "Properties" and the property literal to maintain
                         # Better check than just try/except KeyError :-)
                         if source.get("Properties") and source.get("Properties", {}).get(item[1]):
-                            if not has_intrinsic_functions(source["Properties"][item[1]].keys()):
+                            if isinstance(source["Properties"][item[1]], dict) and \
+                                    not has_intrinsic_functions(source["Properties"][item[1]].keys()):
                                 source["Properties"][item[1]] = LiteralString(u"{}".format(json.dumps(
                                     source["Properties"][item[1]],
                                     indent=2,

--- a/examples/test_json_state_machine.json
+++ b/examples/test_json_state_machine.json
@@ -1,0 +1,15 @@
+{
+   "AWSTemplateFormatVersion":"2010-09-09",
+   "Description":"An example template for a Step Functions state machine.",
+   "Resources":{
+      "MyStateMachine":{
+         "Type":"AWS::StepFunctions::StateMachine",
+         "Properties":{
+            "StateMachineName":"HelloWorld-StateMachine",
+            "StateMachineType":"STANDARD",
+            "DefinitionString":"{\"StartAt\": \"HelloWorld\", \"States\": {\"HelloWorld\": {\"Type\": \"Task\", \"Resource\": \"arn:aws:lambda:us-east-1:111122223333;:function:HelloFunction\", \"End\": true}}}",
+            "RoleArn":"arn:aws:iam::111122223333:role/service-role/StatesExecutionRole-us-east-1;"
+         }
+      }
+   }
+}

--- a/examples/test_yaml_state_machine.yaml
+++ b/examples/test_yaml_state_machine.yaml
@@ -1,0 +1,10 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: An example template for a Step Functions state machine.
+Resources:
+  MyStateMachine:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      StateMachineName: HelloWorld-StateMachine
+      StateMachineType: STANDARD
+      DefinitionString: '{"StartAt": "HelloWorld", "States": {"HelloWorld": {"Type": "Task", "Resource": "arn:aws:lambda:us-east-1:111122223333;:function:HelloFunction", "End": true}}}'
+      RoleArn: arn:aws:iam::111122223333:role/service-role/StatesExecutionRole-us-east-1;

--- a/tests/test_step_functions_template.py
+++ b/tests/test_step_functions_template.py
@@ -1,0 +1,19 @@
+import cfn_flip
+import pytest
+
+
+@pytest.fixture
+def input_json_state_machine():
+    with open("examples/test_json_state_machine.json", "r") as f:
+        return f.read()
+
+
+@pytest.fixture
+def output_yaml_state_machine():
+    with open("examples/test_yaml_state_machine.yaml", "r") as f:
+        return f.read()
+
+
+def test_state_machine_with_str(input_json_state_machine, output_yaml_state_machine):
+    resp = cfn_flip.to_yaml(input_json_state_machine)
+    assert resp == output_yaml_state_machine


### PR DESCRIPTION
Fix when the JSON template contains a StateMachine resource with the payload as string instead of JSON, the library generated an error due to the expected type be Dict. This fix check the instance type before get the keys.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
