### PR TITLE
ci: Fix Codecov upload and use new uploader

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,3 +28,6 @@ jobs:
 
       - name: Run tests
         run: tox
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v2

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,6 @@ deps =
     pytest>=4.3.0
     pytest-cov
     pytest-sugar
-    codecov>=1.4.0
 
 commands =
     py.test \
@@ -28,10 +27,8 @@ commands =
         --cov=cfn_tools \
         --cov-report term-missing \
         --cov-report html \
+        --cov-report xml \
         {posargs}
-    codecov -e TOXENV
-
-passenv = TOXENV CI TRAVIS TRAVIS_*
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Recent Action runs don't seem to be uploading coverage reports to Codecov [like so](https://github.com/awslabs/aws-cfn-template-flip/runs/4561623284?check_suite_focus=true#step:5:78). I migrated over to the new uploader to get around this issue as the python uploader will be deprecated

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
